### PR TITLE
allowScript for newer node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,13 @@ WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install --force --ignore-scripts
+ENV PRISMA_SKIP_POSTINSTALL_GENERATE=true
+
+RUN npm install --force
 
 COPY . .
+
+ENV PRISMA_SKIP_POSTINSTALL_GENERATE=false
 
 RUN npm run prisma:generate
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"start": "cross-env NODE_ENV=production node index.js",
 		"dev": "cross-env NODE_ENV=development nodemon index.js",
 		"deploy": "node ./deploy.js",
-		"postinstall": "npm run prisma:generate",
+		"postinstall": "test -n \"$PRISMA_SKIP_POSTINSTALL_GENERATE\" || npm run prisma:generate",
 		"prisma:generate": "cross-env MONGO=mongodb://localhost:27017/ziji SQLITE_DATABASE_URL=file:./jsons/ziDB.sqlite prisma generate --schema prisma/mongo/schema.prisma && cross-env SQLITE_DATABASE_URL=file:./jsons/ziDB.sqlite prisma generate --schema prisma/sqlite/schema.prisma",
 		"prisma:push:mongo": "prisma db push --schema prisma/mongo/schema.prisma",
 		"prisma:push:sqlite": "cross-env SQLITE_DATABASE_URL=file:./jsons/ziDB.sqlite prisma db push --schema prisma/sqlite/schema.prisma",

--- a/package.json
+++ b/package.json
@@ -86,5 +86,13 @@
 		"discord-giveaways": {
 			"serialize-javascript": "^7.0.5"
 		}
+	},
+	"allowScripts": {
+		"cloudflared@0.7.3": true,
+		"ffmpeg-static@5.3.0": true,
+		"prisma@6.19.3": true,
+		"youtube-dl-exec@3.1.12": true,
+		"@prisma/engines@6.19.3": true,
+		"@prisma/client@6.19.3": true
 	}
 }


### PR DESCRIPTION
# Mô tả / Description

<!-- Vui lòng cung cấp một mô tả ngắn gọn về những thay đổi trong pull request này. -->
<!-- Please provide a brief description of the changes in this pull request. -->
Node / npm phiên bản mới (11.6.0 -> 12) mặc định chặn hoàn toàn `preinstall`, `install`, và `postinstall`, chỉ khi người dùng cấp phép -> field `allowScripts` giải quyết vấn đề đó

# Loại thay đổi / Type of change

<!-- Vui lòng chọn một trong các loại thay đổi dưới đây bằng cách đánh dấu "x" vào ô thích hợp. -->
<!-- Please select one of the following types of change by marking "x" in the appropriate box. -->

- [x] Bug fix (sửa lỗi / fix a bug)
- [ ] New feature (tính năng mới / add a new feature)
- [ ] Breaking change (thay đổi gây ảnh hưởng / breaking change)
- [ ] Documentation update (cập nhật tài liệu / update documentation)
- [ ] Other (khác / other)
